### PR TITLE
Changes this.flags to this.chromeFlags

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const lighthouse = require('./lighthouse');
 const CronJob = require('cron').CronJob;
-const Printer = require('lighthouse/lighthouse-cli/printer');
 const defer = require('promise-defer');
 const EventEmitter = require('events').EventEmitter;
 
@@ -37,7 +36,7 @@ module.exports = class LighthouseCron extends EventEmitter {
   }
 
   _cron(urls) {
-    this._doPromises(urls, this.chrome, this.flags, this.lighthouseConfig);
+    this._doPromises(urls, this.chrome, this.chromeFlags, this.lighthouseConfig);
   }
 
   _promiseWhile(condition, action) {


### PR DESCRIPTION
I've been trying use the chromeFlags with options in the class `LighthouseCron` but it does not work. Looking the code I've seen that you created the property  `this.chromeFlags` in the constructor class but you don't use, you're using the property `this.flags` instead. 

:package:  I removed a variable `Printer` if you don't use too.

If you approve this PR, could you do publish on npm repository? :crab: 